### PR TITLE
Search many locations for unqualified dot program

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ Feng Peng(@QAMichaelPeng)
 With contributions from
 - Dos Santos(@d0ssant0s)
 - ebdavison(@ebdavison)
+- Chad Miller(@chadmiller-saq / @chadmiller)

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -19,13 +19,17 @@ export class Processors {
     ]);
 
   private async writeDotFile(sourceFile: string): Promise<Uint8Array> {
-    return new Promise<Uint8Array>((resolve, reject) => {
-      const cmdPath = this.plugin.settings.dotPath;
-      const imageFormat = this.plugin.settings.imageFormat;
-      const parameters = [ `-T${imageFormat}`, sourceFile ];
+    const LIKELY_LOCATIONS = `/usr/local/bin:/opt/homebrew/bin:/snap/bin:/bin:/usr/bin`;
 
-      console.debug(`Starting dot process ${cmdPath}, ${parameters}`);
-      const dotProcess = spawn(cmdPath, parameters);
+    return new Promise<Uint8Array>((resolve, reject) => {
+      const cmdPath = this.plugin.settings.dotPath.trim();
+      const imageFormat = this.plugin.settings.imageFormat;
+      const alreadyQualified = (cmdPath.contains("/") || cmdPath.contains('\\'));
+      const execPrefix = alreadyQualified ? [] : [ `/usr/bin/env`, `-P`, LIKELY_LOCATIONS ];
+      const execFull = execPrefix.concat([ cmdPath, `-T${imageFormat}`, sourceFile ]);
+
+      console.debug(`Starting dot process [${execFull}]`);
+      const dotProcess = spawn(execFull[0], execFull.slice(1));
       const outData: Array<Uint8Array> = [];
       let errData = '';
 
@@ -37,14 +41,16 @@ export class Processors {
       });
       dotProcess.stdin.end();
       dotProcess.on('exit', function (code) {
-        if (code !== 0) {
-          reject(`"${cmdPath} ${parameters}" failed, error code: ${code}, stderr: ${errData}`);
-        } else {
+        if (code == 0) {
           resolve(Buffer.concat(outData));
+	} else if (code == 127) {
+          reject(`spawn [${execFull}] failed, stderr: ${errData}. Check the dot file path is correct.`);
+        } else {
+          reject(`exit code: ${code}, stderr: ${errData}`);
         }
       });
       dotProcess.on('error', function (err: Error) {
-        reject(`"${cmdPath} ${parameters}" failed, ${err}`);
+        reject(`spawn [${execFull}] failed, ${err}`);
       });
     });
   }


### PR DESCRIPTION
If the name of the dot executable is not qualified with a full path, we should search through some likely locations for it. Use the 'env' program with some likely paths to search through.

(A better way to know where to search would be to get the path from the user's environment, but the javascript runtime seems to scour that away.)

If we fail to complete running, tell the user what the problem probably is. From env man page,
`An exit status of 127 indicates that utility could not be found.`