### PR TITLE
dot-rendered images transparent and shadows added

### DIFF
--- a/src/processors.ts
+++ b/src/processors.ts
@@ -22,7 +22,7 @@ export class Processors {
     return new Promise<Uint8Array>((resolve, reject) => {
       const cmdPath = this.plugin.settings.dotPath;
       const imageFormat = this.plugin.settings.imageFormat;
-      const parameters = [ `-T${imageFormat}`, sourceFile ];
+      const parameters = [ `-T${imageFormat}`, `-Gbgcolor=transparent`, `-Gstylesheet=obs-gviz.css`, sourceFile ];
 
       console.debug(`Starting dot process ${cmdPath}, ${parameters}`);
       const dotProcess = spawn(cmdPath, parameters);

--- a/styles.css
+++ b/styles.css
@@ -2,3 +2,14 @@
   color: red;
   border: 1px solid red;
 }
+
+/* temporary hack until SVG loads CSS */
+.theme-dark .block-language-dot img.graphviz {
+  filter:
+    drop-shadow( 2px  2px 2px var(--text-on-accent))
+    drop-shadow(-2px  2px 2px var(--text-on-accent))
+    drop-shadow( 2px -2px 2px var(--text-on-accent))
+    drop-shadow(-2px -2px 2px var(--text-on-accent))
+  ;
+}
+


### PR DESCRIPTION
Dot used to write opaque white backgrounds. Normally okay until night falls.

Now, write transparent images.

This sucks because the foreground is still dark.

We instead use CSS drop-shadows to draw a text color around the alpha edges, thereby making black-on-black, actually black-over-white-on-black.