### PR TITLE
Add hinting of the graph text for various renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ results in:
 
 ![](doc/asset/image/example.png)
 
+```yaml
+    ```dot
+    graph anundirectedgraph {
+      layout=neato;
+      a -- b -- c;
+    }
+    ```
+```
 
 ## Installation
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { Plugin } from 'obsidian';
 import { DEFAULT_SETTINGS, GraphvizSettings, GraphvizSettingsTab } from './setting';
 import { Processors } from './processors';
+import { Suggesters } from './suggesters';
 
 // Remember to rename these classes and interfaces!
 
@@ -13,6 +14,7 @@ export default class GraphvizPlugin extends Plugin {
     await this.loadSettings();
     this.addSettingTab(new GraphvizSettingsTab(this));
     const processors = new Processors(this);
+    const suggesters = new Suggesters(this);
     const d3Sources = ['https://d3js.org/d3.v5.min.js',
       'https://unpkg.com/@hpcc-js/wasm@0.3.11/dist/index.min.js',
       'https://unpkg.com/d3-graphviz@3.0.5/build/d3-graphviz.js'];
@@ -31,6 +33,8 @@ export default class GraphvizPlugin extends Plugin {
         default:
           this.registerMarkdownCodeBlockProcessor('dot', processors.imageProcessor.bind(processors));
       }
+
+      this.registerEditorSuggest(new Suggesters(this.app, this));
     });
   }
 

--- a/src/suggesters.ts
+++ b/src/suggesters.ts
@@ -1,0 +1,96 @@
+import {
+  App,
+  Editor,
+  EditorPosition,
+  EditorSuggest,
+  EditorSuggestContext,
+  EditorSuggestTriggerInfo,
+  TFile,
+} from "obsidian";
+import type GraphvizPlugin from "src/main";
+
+interface IGraphCompletion {
+  label: string;
+}
+
+export class Suggesters extends EditorSuggest<IGraphCompletion> {
+  app: App;
+  private plugin: GraphvizPlugin;
+
+  constructor(app: App, plugin: GraphvizPlugin) {
+    super(app);
+    this.app = app;
+    this.plugin = plugin;
+
+    // @ts-ignore
+    this.scope.register(["Shift"], "Enter", (evt: KeyboardEvent) => {
+      // @ts-ignore
+      this.suggestions.useSelectedItem(evt);
+      return false;
+    });
+  }
+
+  getSuggestions(context: EditorSuggestContext): IGraphCompletion[] {
+    const suggestions = this.getGraphSuggestions(context);
+    if (suggestions.length) {
+      return suggestions;
+    }
+    return [];
+  }
+
+  getGraphSuggestions(context: EditorSuggestContext): IGraphCompletion[] {
+    const line = context.editor.getLine(context.end.line);
+    return "dot/neato/fdp/sfdp/circo/osage/patchwork"
+        .split("/")
+        .map((app) => ({ label: `${app}` }));
+  }
+
+  renderSuggestion(suggestion: IGraphCompletion, el: HTMLElement): void {
+    el.setText("insert " + suggestion.label + " example");
+  }
+
+  selectSuggestion(suggestion: IGraphCompletion, event: KeyboardEvent | MouseEvent): void {
+    const { editor } = this.context;
+
+    const hints = new Map();
+    hints.set("dot", [ "/*", "a -> b -> a;", "a [color=blue];", "*/" ]);
+    hints.set("neato", [ `mode="major";  // KK/sgd/hier/ipsep`, "/* a -- b -- c; */" ]);
+    hints.set("patchwork", [ `/* "foo" [area=100 fillcolor=gold] */` ]);
+
+    const grouping = (suggestion.label.startsWith("dot")) ? "digraph" : "graph";
+    const result = `
+${grouping} ${suggestion.label[0]} {
+    layout=${suggestion.label};
+` + ((hints.get(suggestion.label) || []).map((l) => `    ${l}`).join("\n"));
+
+    editor.replaceRange(result + "\n\n}", this.context.end);
+  }
+
+  onTrigger(
+    cursor: EditorPosition,
+    editor: Editor,
+    file: TFile
+  ): EditorSuggestTriggerInfo {
+    const triggerPhrase = "```dot";
+    const startPos = this.context?.start || {
+      line: cursor.line,
+      ch: cursor.ch - triggerPhrase.length,
+    };
+
+    if (!editor.getRange(startPos, cursor).startsWith(triggerPhrase)) {
+      return null;
+    }
+
+    console.dir(editor.getLine(cursor.line + 1));
+
+    if (editor.getLine(cursor.line + 1) != "```") {
+      return null;
+    }
+
+    return {
+      start: startPos,
+      end: cursor,
+      query: editor.getRange(startPos, cursor).substring(triggerPhrase.length),
+    };
+  }
+}


### PR DESCRIPTION
After "```dot" constructs a new block
\`\`\`dot
\`\`\`
we will be presented with a selection of example documents to insert with layout engines specified and sometimes sample lines showing directed edges or undirected or no edges at all, depending on the graph type.  "insert neato example" eg